### PR TITLE
Plain markdown titles in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,21 +5,21 @@ cassowary.hx
 
 A direct Haxe port of the cassowary.js implementation of the Cassowary constraint solving algorithm. The port includes minor changes to the js born API to deal with the changes to a strong typed language. The port also includes and passes all the original js version test cases.
 
-**Important**
+#### Important
 
 - This code was a direct port of [cassowary.js](https://github.com/slightlyoff/cassowary.js/) 
 - The code may be behind current cassowary.js by a bit
 - The code is not fully optimized for Haxe (as it was born in js)
 
-**Future**
+#### Future
 
 While the port is complete, I have since moved on to a smaller, cleaner, stronger typed port and implementation. When uploaded, I'll link to the new version instead.
 
-**License**
+#### License
 
 - This code is licensed as MIT
 - Cassowary.js is licensed as Apache 2.0
 
- **Community**
+#### Community
  
 Curious about similar projects? Head over to [overconstrained.io](http://overconstrained.io) and [join us](https://overconstrained-slack.herokuapp.com/) on slack.


### PR DESCRIPTION
Seems like there was something odd about the "community" title. It had a margin on left side.
